### PR TITLE
fix charges/invoices listing by using stripe API as suggested in http…

### DIFF
--- a/pinax/stripe/actions/charges.py
+++ b/pinax/stripe/actions/charges.py
@@ -160,7 +160,7 @@ def sync_charges_for_customer(customer):
     Args:
         customer: a pinax.stripe.models.Customer object
     """
-    for charge in customer.stripe_customer.charges().data:
+    for charge in stripe.Charge.auto_paging_iter(customer=customer.stripe_id):
         sync_charge_from_stripe_data(charge)
 
 

--- a/pinax/stripe/actions/invoices.py
+++ b/pinax/stripe/actions/invoices.py
@@ -131,7 +131,7 @@ def sync_invoices_for_customer(customer):
     Args:
         customer: the customer for whom to synchronize all invoices
     """
-    for invoice in customer.stripe_customer.invoices().data:
+    for invoice in stripe.Invoice.auto_paging_iter(customer=customer.stripe_id):
         sync_invoice_from_stripe_data(invoice, send_receipt=False)
 
 

--- a/pinax/stripe/tests/test_actions.py
+++ b/pinax/stripe/tests/test_actions.py
@@ -1666,17 +1666,17 @@ class SyncsTests(TestCase):
         self.assertFalse(SyncSubscriptionMock.called)
         self.assertTrue(PurgeLocalMock.called)
 
-    @patch("pinax.stripe.actions.invoices.sync_invoice_from_stripe_data")
+    @patch("stripe.Invoice.auto_paging_iter")
     @patch("stripe.Customer.retrieve")
-    def test_sync_invoices_for_customer(self, RetreiveMock, SyncMock):
-        RetreiveMock().invoices().data = [Mock()]
+    def test_sync_invoices_for_customer(self, RetrieveMock, SyncMock):
+        RetrieveMock.return_value = [Mock()]
         invoices.sync_invoices_for_customer(self.customer)
         self.assertTrue(SyncMock.called)
 
-    @patch("pinax.stripe.actions.charges.sync_charge_from_stripe_data")
+    @patch("stripe.Charge.auto_paging_iter")
     @patch("stripe.Customer.retrieve")
-    def test_sync_charges_for_customer(self, RetreiveMock, SyncMock):
-        RetreiveMock().charges().data = [Mock()]
+    def test_sync_charges_for_customer(self, RetrieveMock, SyncMock):
+        RetrieveMock.return_value = [Mock()]
         charges.sync_charges_for_customer(self.customer)
         self.assertTrue(SyncMock.called)
 


### PR DESCRIPTION
#### What's this PR do?
As described in #623 `invoices` is no longer available in the pulled stripe customer data, thus pulling invoices list from the stripe API separately with customer id. Suggested by @polski-g in his comment: https://github.com/pinax/pinax-stripe/issues/623\#issuecomment-455814540

Same goes for `charges` as noted by the user in the comment. 

#### Any background context you want to provide?

#### What ticket or issue # does this fix?

Closes #623

#### Definition of Done (check if considered and/or addressed):

- [x] Are all backwards incompatible changes documented in this PR?
- [x] Have all new dependencies been documented in this PR?
- [x] Has the appropriate documentation been updated (if applicable)?
- [x] Have you written tests to prove this change works (if applicable)?
